### PR TITLE
AWS教材の詳細実装途中

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,8 @@ gem 'rails-i18n'
 gem 'devise-i18n'
 gem 'devise-bootstrap-views'
 gem 'activeadmin'
+gem 'redcarpet'
+gem 'coderay'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,6 +202,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (2.3.0)
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -259,6 +260,7 @@ DEPENDENCIES
   activeadmin
   bootsnap (>= 1.4.2)
   byebug
+  coderay
   devise
   devise-bootstrap-views
   devise-i18n
@@ -271,6 +273,7 @@ DEPENDENCIES
   puma (~> 4.1)
   rails (~> 6.0.3)
   rails-i18n
+  redcarpet
   sass-rails (>= 6)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/controllers/aws_texts_controller.rb
+++ b/app/controllers/aws_texts_controller.rb
@@ -1,9 +1,10 @@
-class TextsController < ApplicationController
+class AwsTextsController < ApplicationController
   def index
     @aws_texts = AwsText.all
   end
+
   def show
     @aws_text = AwsText.find(params[:id])
-
   end
+
 end

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -2,4 +2,8 @@ class TextsController < ApplicationController
   def index
     @aws_texts = AwsText.all
   end
+  def show
+    @aws_text = AwsText.find(params[:id])
+
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,3 +1,48 @@
 module ApplicationHelper
-  
+  require "redcarpet"
+  require "coderay"
+
+    class HTMLwithCoderay < Redcarpet::Render::HTML
+        def block_code(code, language)
+            language = language.split(':')[0] if language.present?
+
+            case language.to_s
+            when 'rb'
+                lang = :ruby
+            when 'yml'
+                lang = :yaml
+            when 'css'
+                lang = :css
+            when 'html'
+                lang = :html
+            when ''
+                lang = :md
+            else
+                lang = language
+            end
+
+            CodeRay.scan(code, lang).div
+        end
+    end
+
+    def markdown(text)
+        html_render = HTMLwithCoderay.new(
+          filter_html: true,
+          hard_wrap: true,
+          link_attributes: { rel: 'nofollow', target: "_blank" }
+        )
+        options = {
+            autolink: true,
+            space_after_headers: true,
+            no_intra_emphasis: true,
+            fenced_code_blocks: true,
+            tables: true,
+            hard_wrap: true,
+            xhtml: true,
+            lax_html_blocks: true,
+            strikethrough: true
+        }
+        markdown = Redcarpet::Markdown.new(html_render, options)
+        markdown.render(text)
+    end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,3 @@
 module ApplicationHelper
+  
 end

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,0 +1,21 @@
+module MarkdownHelper
+  def markdown(text)
+    options = {
+      hard_wrap:       true,
+      space_after_headers: true,
+    }
+
+    extensions = {
+      autolink:           true,
+      no_intra_emphasis:  true,
+      fenced_code_blocks: true,
+    }
+
+    unless @markdown
+      renderer = Redcarpet::Render::HTML.new(options)
+      @markdown = Redcarpet::Markdown.new(renderer, extensions)
+    end
+
+    @markdown.render(text).html_safe
+  end
+end

--- a/app/views/aws_texts/index.html.erb
+++ b/app/views/aws_texts/index.html.erb
@@ -14,9 +14,11 @@
     <% @aws_texts.each.with_index(1) do |text,index| %>
       <tr>
         <td scope="row"><%= index %></td>
-        <td><a href="#"><%= link_to text.title, admin_aws_text_path(text.id) %></a></td>
+        <td><%= link_to text.title, aws_text_path(text.id) %></td>
+        
       </tr>
     <% end %>
+    
   </tbody>
 </table>
 </div>

--- a/app/views/aws_texts/index.html.erb
+++ b/app/views/aws_texts/index.html.erb
@@ -1,3 +1,4 @@
+
 <div class="aws_text">
 <h2>AWS講座</h2>
 <p>注意！！！：AWSのEC2やRDSは有料サービスとなります。無駄な料金を請求されないためにも、不要なインスタンスは停止・削除をしてください。</p>
@@ -6,14 +7,14 @@
   <thead>
     <tr style="background-color:#5D99FF;">
       <th scope="col" style="color:white">No.</th>
-      <th scope="col" style="color:white"><%= link_to "内容" , admin_aws_text_path(@aws_text.id) %></th>
+      <th scope="col" style="color:white">内容</th>
     </tr>
   </thead>
   <tbody>
     <% @aws_texts.each.with_index(1) do |text,index| %>
       <tr>
         <td scope="row"><%= index %></td>
-        <td><a href="#"><%= text.title %></a></td>
+        <td><a href="#"><%= link_to text.title, admin_aws_text_path(text.id) %></a></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/aws_texts/show.html.erb
+++ b/app/views/aws_texts/show.html.erb
@@ -1,0 +1,2 @@
+<h1>AwsTexts#show</h1>
+<p>Find me in app/views/aws_texts/show.html.erb</p>

--- a/app/views/aws_texts/show.html.erb
+++ b/app/views/aws_texts/show.html.erb
@@ -1,4 +1,2 @@
-<%
-  text = @aws_text.content
-%>
-<%= markdown(text).html_safe %>
+<h1><%= @aws_text.title %></h1>
+<%= markdown(@aws_text.content).html_safe %>

--- a/app/views/aws_texts/show.html.erb
+++ b/app/views/aws_texts/show.html.erb
@@ -1,2 +1,4 @@
-<h1>AwsTexts#show</h1>
-<p>Find me in app/views/aws_texts/show.html.erb</p>
+<%
+  text = @aws_text.content
+%>
+<%= markdown(text).html_safe %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -14,7 +14,7 @@
        </div>
      </li>
      <li class="nav-item">
-       <a class="nav-link"  href="/aws">AWS講座</a>
+       <a class="nav-link"  href="/aws_texts">AWS講座</a>
      </li>
      <li class="nav-item">
        <a class="nav-link"  href="#">PHP講座</a>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -6,7 +6,7 @@
   <thead>
     <tr style="background-color:#5D99FF;">
       <th scope="col" style="color:white">No.</th>
-      <th scope="col" style="color:white">内容</th>
+      <th scope="col" style="color:white"><%= link_to "内容" , admin_aws_text_path(@aws_text.id) %></th>
     </tr>
   </thead>
   <tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,5 @@ Rails.application.routes.draw do
   devise_for :users
   root to: 'movies#index'
   resources :movies, only: :index
-  get "/aws",to:"texts#index"
+  resources :aws_texts
 end


### PR DESCRIPTION
1.Markdown導入のため、gemをインストール

2.application_helper.rbファイルを作成デフォルトのコードを追加

3.aws_texts_controller.rbファイルを作成

4.aws_textsに中身を移行後、
 texts_controller.rb,それに付随するviewを削除

5.aws_texts_controller.rbにshowアクションを追加

6.内容から詳細へ行けるように
aws_texts/index.html.erbを変更しました。

7.詳細ページの作成
show.html.erbを作成し、
マークダウン表示が出来るようコードを追加しました。
```

<h1><%= @aws_text.title %></h1>
<%= markdown(@aws_text.content).html_safe %>

```