### PR TITLE
テキスト教材の画像

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,8 @@ gem 'activeadmin'
 gem 'redcarpet'
 gem 'coderay'
 gem 'kaminari'
+gem 'carrierwave'
+gem 'rmagick'
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,8 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     arbre (1.2.1)
       activesupport (>= 3.0.0)
     bcrypt (3.1.13)
@@ -75,6 +77,13 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
+    carrierwave (2.1.0)
+      activemodel (>= 5.0.0)
+      activesupport (>= 5.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      mimemagic (>= 0.3.0)
+      mini_mime (>= 0.1.3)
     coderay (1.1.2)
     concurrent-ruby (1.1.6)
     crass (1.0.6)
@@ -99,6 +108,9 @@ GEM
       activesupport (>= 4.1)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
+    image_processing (1.11.0)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     inherited_resources (1.11.0)
       actionpack (>= 5.0, < 6.1)
       has_scope (~> 0.6)
@@ -135,6 +147,7 @@ GEM
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
     mimemagic (0.3.5)
+    mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.1)
@@ -157,6 +170,7 @@ GEM
       yard (~> 0.9.11)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
+    public_suffix (4.0.5)
     puma (4.3.5)
       nio4r (~> 2.0)
     rack (2.2.2)
@@ -206,6 +220,9 @@ GEM
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    rmagick (4.1.2)
+    ruby-vips (2.0.17)
+      ffi (~> 1.9)
     ruby_dep (1.5.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -260,6 +277,7 @@ DEPENDENCIES
   activeadmin
   bootsnap (>= 1.4.2)
   byebug
+  carrierwave
   coderay
   devise
   devise-bootstrap-views
@@ -275,6 +293,7 @@ DEPENDENCIES
   rails (~> 6.0.3)
   rails-i18n
   redcarpet
+  rmagick
   sass-rails (>= 6)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/admin/texts.rb
+++ b/app/admin/texts.rb
@@ -1,0 +1,4 @@
+ActiveAdmin.register Text do
+  permit_params :image, :genre, :title, :content
+
+end

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -126,6 +126,13 @@ nav .dropdown-item{
   width: 100%;
   height: 100%;
 }
+.card{
+  margin: 20px 0;
+}
+.card-img{
+  width: 400px;
+  height: 180px;
+}
 .card-body {
   height: 160px;
   background-color: #f7f7f7;
@@ -143,6 +150,7 @@ nav .dropdown-item{
 .text {
   padding: 60px 0 20px 0;
 }
+
 .text input{
   padding: 10px 0;
   margin-bottom: 20px;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -122,7 +122,10 @@ nav .dropdown-item{
   width: 450px;
   margin: 0 auto;
 }
-
+.card{
+  width: 100%;
+  height: 100%;
+}
 .card-body {
   height: 160px;
   background-color: #f7f7f7;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,7 +1,7 @@
 @import "bootstrap/scss/bootstrap";
 
 main {
-  max-width: 992px;
+
   margin: 0 auto;
   padding: 1rem;
   padding-bottom: 50px;
@@ -124,19 +124,31 @@ nav .dropdown-item{
 }
 
 .card-body {
-  width: 250px;
   height: 160px;
+  background-color: #f7f7f7;
+}
+.card-body h4{
+  text-align: left;
+  font-size: 16px;
+}
+.card-body p{
+  font-size: 16px;
+  padding-top: 60px;
+  text-align: left;
 }
 
 .text {
-  padding: 40px 0 20px 0;
+  padding: 60px 0 20px 0;
+}
+.text input{
+  padding: 10px 0;
+  margin-bottom: 20px;
 }
 .text-show {
   padding: 120px 0 80px 0;
   text-align: left;
   font-size: 20px;
 }
-
 .text-title {
   font-size: 30px;
   font-weight: bold;

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -1,2 +1,3 @@
 class Text < ApplicationRecord
+  mount_uploader :image, ImageUploader
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,0 +1,25 @@
+class ImageUploader < CarrierWave::Uploader::Base
+  include CarrierWave::RMagick
+  storage :file
+  process convert: 'jpg'
+  # 保存するディレクトリ名
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+  # thumb バージョン(width 400px x height 200px)
+  version :thumb do
+    process :resize_to_fit => [400, 200]
+  end
+  # 許可する画像の拡張子
+  def extension_white_list
+    %W[jpg jpeg gif png]
+  end
+  # 変換したファイルのファイル名の規則
+  def filename
+    "#{Time.zone.now.strftime('%Y%m%d%H%M%S')}.jpg" if original_filename.present?
+  end
+
+  def default_url(*args)
+    "no_image.jpeg"
+  end
+end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -16,7 +16,13 @@ class ImageUploader < CarrierWave::Uploader::Base
   end
   # 変換したファイルのファイル名の規則
   def filename
-    "#{Time.zone.now.strftime('%Y%m%d%H%M%S')}.jpg" if original_filename.present?
+    "#{secure_token}.#{file.extension}" if original_filename.present?
+  end
+
+  protected
+  def secure_token
+    var = :"@#{mounted_as}_secure_token"
+    model.instance_variable_get(var) or model.instance_variable_set(var, SecureRandom.uuid)
   end
 
   def default_url(*args)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,7 @@
     <%= render "layouts/header" %>
     <%= render "layouts/flash_messages" %>
   </header>
-  <main style=max-width:<%= controller.controller_name == "texts" ? "1350" : "700"%>px; >
+  <main style=max-width:<%= controller.controller_name == "texts" && controller.action_name == "index" ? "1350" : "700"%>px;>
     <%= yield %>
   </main>
   <footer>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,7 @@
     <%= render "layouts/header" %>
     <%= render "layouts/flash_messages" %>
   </header>
-  <main style=max-width:<%= controller.controller_name == "texts" && controller.action_name == "index" ? "1350" : "700"%>px;>
+  <main style=max-width:<%= controller.controller_name == "texts" && controller.action_name == "index" ? "1300" : "700"%>px;>
     <%= yield %>
   </main>
   <footer>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,7 @@
     <%= render "layouts/header" %>
     <%= render "layouts/flash_messages" %>
   </header>
-  <main>
+  <main style=max-width:<%= controller.controller_name == "texts" ? "1350" : "700"%>px; >
     <%= yield %>
   </main>
   <footer>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,30 +1,27 @@
 <div class="text">
-  <div class="input-group">
-    <input type="text" class="form-control" placeholder="テキスト入力欄" style="width:100px;">
+  <div class="input-group justify-content-center">
+    <input type="text" placeholder="　教材を探す" style="width:30%;">
     <span class="input-group-btn">
       <button type="button" class="btn btn-default"></button>
     </span>
   </div>
   <h3 class="text-center">テキスト教材</h3>
 
-<div class="container">
-
-  <div class="row">
-    <div class="card-deck">
-        <% @texts.each do |text| %>
-      <div class="col-md-4">
-
-          <a target="_blank" href="/texts/<%= text.id %>" class="btn text_content">
-            <div class="card">
-              <img class="card-img" src="/assets/no_image.jpeg" ait="サンプル画像">
-              <div class="card-body">
-                <h4 class="card-title"><%= "#{text.title}" %></h4>
-                <p class="card-text"><%= "【#{text.genre}】" %></p>
-              </div>
+  <div class="container-fluid">
+    <div class="row">
+      <% @texts.each do |text| %>
+       <div class="col-md-4">
+         <a target="_blank" href="/texts/<%= text.id %>" class="btn text_content">
+          <div class="card">
+            <%= image_tag text.image_url(:thumb) ,class:"card-img" %>
+            <div class="card-body">
+              <h4 class="card-title"><%= "#{text.title}" %></h4>
+              <p class="card-text"><%= "【#{text.genre}】" %></p>
             </div>
-        </a>
-      </div>
-        <% end %>
+          </div>
+         </a>
+       </div>
+          <% end %>
     </div>
   </div>
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,6 +5,8 @@ ja:
       aws_text: "AWSテキスト"
       comment: "コメント"
       admin_user: "管理者"
+      question: "質問集"
+      text: "テキスト"
     attributes:
       movie:
         title: "タイトル"

--- a/db/migrate/20200624111929_add_image_to_texts.rb
+++ b/db/migrate/20200624111929_add_image_to_texts.rb
@@ -1,0 +1,5 @@
+class AddImageToTexts < ActiveRecord::Migration[6.0]
+  def change
+    add_column :texts, :image, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_22_174250) do
+ActiveRecord::Schema.define(version: 2020_06_24_111929) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -127,6 +127,7 @@ ActiveRecord::Schema.define(version: 2020_06_22_174250) do
     t.text "content"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "image"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
**実装内容**
- carrierwaveとrmagickのgemを導入
- Textモデルにimagesカラムを追加
- 画像の初期値をセットして、管理者画面から画像を変えれるように実装
- テキスト教材一覧ページのデザインの微調整

**参考文献**
- 逆転教材のテキスト教材「画像投稿機能」
- https://qiita.com/Akito_qiita/items/a6382efd410fe5544406